### PR TITLE
make it explicit that those are not for TLS 1.2

### DIFF
--- a/draft-tls-westerbaan-mldsa.md
+++ b/draft-tls-westerbaan-mldsa.md
@@ -39,6 +39,7 @@ author:
 normative:
 
 informative:
+ RFC5246:
  RFC8446:
  TLSIANA: I-D.ietf-tls-rfc8447bis
  I-D.ietf-lamps-dilithium-certificates:
@@ -91,6 +92,11 @@ MUST be the empty string.
 The corresponding end-entity certificate when negotiated MUST
 use id-ML-DSA-44, id-ML-DSA-65, id-ML-DSA-87 respectively as
 defined in {{I-D.ietf-lamps-dilithium-certificates}}.
+
+The schemes defined in this document MUST NOT be used in TLS 1.2 {{RFC5246}}.
+A peer that receives ServerKeyExchange or CertificateVerify message in a TLS
+1.2 connection with schemes defined in this document MUST abort the connection
+with an illegal_parameter alert.
 
 # Security Considerations
 


### PR DESCRIPTION
in context of https://datatracker.ietf.org/doc/draft-ietf-tls-tls12-frozen/, we should be explicit that those new schemes MUST NOT be used in TLS 1.2